### PR TITLE
feat(template-form): display and edit description field

### DIFF
--- a/components/templates/TemplateForm.tsx
+++ b/components/templates/TemplateForm.tsx
@@ -35,6 +35,7 @@ import PersonalizationTags from "@/components/email/PersonalizationTags";
 
 const templateFormSchema = z.object({
   name: z.string().min(1, "Template name is required"),
+  description: z.string().optional(),
   category: z.nativeEnum(TemplateCategory),
   subject: z.string().min(1, "Subject line is required"),
   body: z.string().min(1, "Email body is required"),
@@ -64,11 +65,15 @@ export function TemplateForm({
       category: TemplateCategory.OUTREACH,
       subject: "",
       body: "",
+      description: "",
     },
     mode: "onChange",
   });
 
-  const handleSubmit = async (data: TemplateFormValues, event?: React.BaseSyntheticEvent) => {
+  const handleSubmit = async (
+    data: TemplateFormValues,
+    event?: React.BaseSyntheticEvent
+  ) => {
     event?.preventDefault();
     await onSubmit(data);
   };
@@ -107,6 +112,28 @@ export function TemplateForm({
                 <FormControl>
                   <Input
                     placeholder={t.newTemplate.form.name.placeholder}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description" 
+            render={({ field }) => (
+              <FormItem className="col-span-3">
+                <FormLabel>
+                  {t.newTemplate.form.description?.label ?? "Description"}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder={
+                      t.newTemplate.form.description?.placeholder ??
+                      "Enter a description"
+                    }
                     {...field}
                   />
                 </FormControl>
@@ -214,8 +241,12 @@ export function TemplateForm({
               {t.newTemplate.actions.cancel}
             </Button>
           )}
-          <Button type="submit" disabled={form.formState.isSubmitting} onClick={form.handleSubmit(handleSubmit)}>
-          <Save className="mr-2 h-4 w-4" />
+          <Button
+            type="submit"
+            disabled={form.formState.isSubmitting}
+            onClick={form.handleSubmit(handleSubmit)}
+          >
+            <Save className="mr-2 h-4 w-4" />
             {form.formState.isSubmitting ? submitLoadingLabel : submitLabel}
           </Button>
         </div>

--- a/components/templates/TemplateViewMode.tsx
+++ b/components/templates/TemplateViewMode.tsx
@@ -13,6 +13,11 @@ export function TemplateViewMode({ template }: TemplateViewModeProps) {
         <div className="text-sm font-medium text-muted-foreground mb-1">{t.category.label}</div>
         <div>{template.category}</div>
       </div>
+
+      <div>
+        <div className="text-sm font-medium text-muted-foreground mb-1">{t.description.label}</div>
+        <div>{template.description}</div>
+      </div>
       
       <div>
         <div className="text-sm font-medium text-muted-foreground mb-1">{t.subjectLine.label}</div>

--- a/components/templates/copy.ts
+++ b/components/templates/copy.ts
@@ -88,6 +88,10 @@ export const copyText = {
         label: "Email Body",
         placeholder: "Write your email content here...",
         tooltip: "Use personalization tags to make your emails more personal."
+      },
+      description: {
+        label: "Description",
+        placeholder: "Enter a brief description of the template"
       }
     },
     actions: {
@@ -127,5 +131,8 @@ export const copyText = {
   },
   created: {
     label: "Created"
+  },
+  description: {
+    label: "Description",
   }
 } as const;


### PR DESCRIPTION
Display and edit description in TemplateForm
Changes made
The description field now displays correctly in the template form.
Ensures the description value is correctly initialized from initialData when editing a template.
The field description is aligned with the other form fields.

![image](https://github.com/user-attachments/assets/7b01d988-f998-4954-91a4-d798392874c3)
